### PR TITLE
Add support for `debuginfo` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # CodeCosts.jl
+[![Build Status](https://travis-ci.com/kimikage/CodeCosts.jl.svg?branch=master)](https://travis-ci.com/kimikage/CodeCosts.jl)
+[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/C/CodeCosts.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)
+[![Codecov](https://codecov.io/gh/kimikage/CodeCosts.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/kimikage/CodeCosts.jl)
 
 This package provides a variant of `@code_typed` with [estimated costs for the
 inlining](https://docs.julialang.org/en/v1/devdocs/inference/#The-inlining-algorithm-(inline_worthy)-1).
@@ -22,7 +25,7 @@ CodeCostsInfo(
    1 │   %7  = Base.slt_int(%6, 0)::Bool
    1 │   %8  = Base.bitcast(Base.Int64, %2)::Int64
    1 │   %9  = Base.slt_int(%8, 0)::Bool
-   1 │   %10 = Base.not_int(%7)::Bool
+   0 │   %10 = Base.not_int(%7)::Bool
    1 │   %11 = Base.and_int(%9, %10)::Bool
    1 │   %12 = Base.or_int(%5, %11)::Bool
    2 │   %13 = Base.ne_float(%2, %2)::Bool
@@ -34,10 +37,10 @@ CodeCostsInfo(
    0 └──       return %18
      )
 , CodeCostsSummary(
-     zero:  1|
-    cheap: 13| 1111111111111
+     zero:  2|
+    cheap: 12| 111111111111
    middle: 10| 4===2=2=2=
 expensive: 20| 20==================
-    total: 43| 100 (default threshold)
+    total: 42| 100 (default threshold)
 ))
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using CodeCosts
+using CodeCosts: costs
 using InteractiveUtils
 using Test
 
@@ -18,7 +19,7 @@ v"1.6.0-DEV.0" <= VERSION < v"1.7.0-DEV.0" && @testset "Basic v1.6" begin
         res = @code_costs func_000(1.0f0)
         show(res)
         println()
-        @test res.costs == [1, 1, 1, 1, 20, 1, 4, 0, 0]
+        @test costs(res) == [1, 1, 1, 1, 20, 1, 4, 0, 0]
 
         print(buf, res.summary)
         @test String(take!(buf)) == """
@@ -30,8 +31,10 @@ v"1.6.0-DEV.0" <= VERSION < v"1.7.0-DEV.0" && @testset "Basic v1.6" begin
                                         total: 29| 100 (default threshold)
                                     )"""
 
-        res = @code_costs func_000(1.0)
-        @test res.costs == [1, 1, 20, 4, 0, 0]
+        res = @code_costs debuginfo=:source func_000(1.0)
+        show(res)
+        println()
+        @test costs(res) == [1, 1, 20, 4, 0, 0]
     end
 end
 
@@ -40,7 +43,7 @@ v"1.5.0-DEV.0" <= VERSION < v"1.6.0-DEV.0" && @testset "Basic v1.5" begin
         res = @code_costs func_000(1.0f0)
         show(res)
         println()
-        @test res.costs == [1, 1, 1, 1, 20, 1, 4, 0, 0]
+        @test costs(res) == [1, 1, 1, 1, 20, 1, 4, 0, 0]
 
         print(buf, res.summary)
         @test String(take!(buf)) == """
@@ -52,8 +55,10 @@ v"1.5.0-DEV.0" <= VERSION < v"1.6.0-DEV.0" && @testset "Basic v1.5" begin
                                         total: 29| 100 (default threshold)
                                     )"""
 
-        res = @code_costs func_000(1.0)
-        @test res.costs == [1, 1, 20, 4, 0, 0]
+        res = @code_costs debuginfo=:source func_000(1.0)
+        show(res)
+        println()
+        @test costs(res) == [1, 1, 20, 4, 0, 0]
     end
 end
 
@@ -62,7 +67,7 @@ v"1.4" <= VERSION < v"1.5.0-DEV.0" && @testset "Basic v1.4" begin
         res = @code_costs func_000(1.0f0)
         show(res)
         println()
-        @test res.costs == [1, 1, 1, 1, 20, 1, 4, 0, 0]
+        @test costs(res) == [1, 1, 1, 1, 20, 1, 4, 0, 0]
 
         print(buf, res.summary)
         @test String(take!(buf)) == """
@@ -74,8 +79,10 @@ v"1.4" <= VERSION < v"1.5.0-DEV.0" && @testset "Basic v1.4" begin
                                         total: 29| 100 (default threshold)
                                     )"""
 
-        res = @code_costs func_000(1.0)
-        @test res.costs == [1, 1, 20, 4, 0, 0]
+        res = @code_costs debuginfo=:source func_000(1.0)
+        show(res)
+        println()
+        @test costs(res) == [1, 1, 20, 4, 0, 0]
     end
 end
 
@@ -84,7 +91,7 @@ v"1.0" <= VERSION < v"1.1" && @testset "Basic v1.0" begin
         res = @code_costs func_000(1.0f0)
         show(res)
         println()
-        @test res.costs == [1, 1, 1, 1, 20, 1, 4, 0, 0]
+        @test costs(res) == [1, 1, 1, 1, 20, 1, 4, 0, 0]
 
         print(buf, res.summary)
         @test String(take!(buf)) == """
@@ -95,7 +102,9 @@ v"1.0" <= VERSION < v"1.1" && @testset "Basic v1.0" begin
                                     expensive: 20| 20==================
                                         total: 29| 100 (default threshold)
                                     )"""
-        res = @code_costs func_000(1.0)
-        @test res.costs == [1, 1, 20, 4, 0, 0]
+        res = @code_costs debuginfo=:source func_000(1.0)
+        show(res)
+        println()
+        @test costs(res) == [1, 1, 20, 4, 0, 0]
     end
 end


### PR DESCRIPTION
This supports `debuginfo` in a brute force manner.
(cf. https://travis-ci.com/github/kimikage/CodeCosts.jl/jobs/379398468#L228)

The `optimize` option, on the other hand, is still unavailable. I don't think it's needed for the `@code_costs`.

This also changes the timing of elimination of `code_coverage_effect` from constructing time to printing time, so that it does not break the integrity of the `CodeInfo`.  (Normal use in the REPL is not affected by this change, though.)

Fixes #8