### PR TITLE
Reduce misalignment within multi-line statements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CodeCosts"
 uuid = "01031290-36d5-4888-8ad8-581b08f8a907"
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/CodeCosts.jl
+++ b/src/CodeCosts.jl
@@ -128,7 +128,7 @@ function Base.show(io::IO, costsinfo::CodeCostsInfo; debuginfo::Symbol=:source)
         if VERSION >= v"1.1" && debuginfo !== :none
             shash = _code_hash(l)
             if shash !== nhash
-                println(io, " "^5, line)
+                println(io, " "^5, l)
                 continue
             end
             n = readline(buf_n)
@@ -136,6 +136,11 @@ function Base.show(io::IO, costsinfo::CodeCostsInfo; debuginfo::Symbol=:source)
         end
 
         if 0 < idx <= length(costsinfo.costs)
+            # multi-line statement
+            if !occursin(r"(?:^|\e\[6G)(?:\e\[[^m]*m|\s)*(?:\d+ |│|└)", l)
+                println(io, " "^5, l)
+                continue
+            end
             # skip code_coverage_effect
             if Meta.isexpr(costsinfo.ci.code[idx], :code_coverage_effect)
                 idx += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ end
 
 @inline func_000(x::T) where T = (x + 1/3, x - oneunit(T), x / 3.0, x * 5.0)
 
+func_001(x) = :(if $x > 0; true; else false; end)
+
 buf = IOBuffer()
 
 v"1.6.0-DEV.0" <= VERSION < v"1.7.0-DEV.0" && @testset "Basic v1.6" begin
@@ -35,6 +37,16 @@ v"1.6.0-DEV.0" <= VERSION < v"1.7.0-DEV.0" && @testset "Basic v1.6" begin
         show(res)
         println()
         @test costs(res) == [1, 1, 20, 4, 0, 0]
+    end
+
+    @testset "func_001" begin
+        res = @code_costs func_001(1)
+        show(res)
+        println()
+
+        print(buf, res)
+        @test occursin(r"\n   0 └──      return %\d\n", String(take!(buf)))
+        @test costs(res) == [100, 100, 100, 100, 0]
     end
 end
 
@@ -60,6 +72,16 @@ v"1.5.0-DEV.0" <= VERSION < v"1.6.0-DEV.0" && @testset "Basic v1.5" begin
         println()
         @test costs(res) == [1, 1, 20, 4, 0, 0]
     end
+
+    @testset "func_001" begin
+        res = @code_costs func_001(1)
+        show(res)
+        println()
+
+        print(buf, res)
+        @test occursin(r"\n   0 └──      return %\d\n", String(take!(buf)))
+        @test costs(res) == [100, 100, 100, 100, 0]
+    end
 end
 
 v"1.4" <= VERSION < v"1.5.0-DEV.0" && @testset "Basic v1.4" begin
@@ -84,6 +106,16 @@ v"1.4" <= VERSION < v"1.5.0-DEV.0" && @testset "Basic v1.4" begin
         println()
         @test costs(res) == [1, 1, 20, 4, 0, 0]
     end
+
+    @testset "func_001" begin
+        res = @code_costs func_001(1)
+        show(res)
+        println()
+
+        print(buf, res)
+        @test occursin(r"\n   0 └──      return %\d\n", String(take!(buf)))
+        @test costs(res) == [100, 100, 100, 100, 0]
+    end
 end
 
 v"1.0" <= VERSION < v"1.1" && @testset "Basic v1.0" begin
@@ -106,5 +138,15 @@ v"1.0" <= VERSION < v"1.1" && @testset "Basic v1.0" begin
         show(res)
         println()
         @test costs(res) == [1, 1, 20, 4, 0, 0]
+    end
+
+    @testset "func_001" begin
+        res = @code_costs func_001(1)
+        show(res)
+        println()
+
+        print(buf, res)
+        @test occursin(r"\n   0    └──      return %\d\n", String(take!(buf)))
+        @test costs(res) == [100, 100, 100, 100, 0]
     end
 end


### PR DESCRIPTION
This reduces misalignment by means of a heuristic.

Perhaps this is an imperfect measure, but I don't think misalignment in corner cases is a critical problem to be solved in this package.

Fixes #11